### PR TITLE
ci: bump actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         mkdir -p pkg
         gem build *.gemspec -o pkg/tiktok_ads_api.gem
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tiktok_ads_api-gem
         path: pkg/tiktok_ads_api.gem


### PR DESCRIPTION
v3 is deprecated and automatically fails per GitHub's April 2024 announcement.